### PR TITLE
添加extractCSS选项

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 var path = require('path');
-var chalk = require('chalk')
 var objectAssign = require('object-assign');
 var hashSum = require('hash-sum');
 var compiler = require('vue-template-compiler');
-var transpile = require('vue-template-es2015-compiler');
+
+var compileTemplate = require('./lib/template-compiler');
 
 // exports
 module.exports = function(content, file, conf) {
@@ -67,29 +67,17 @@ module.exports = function(content, file, conf) {
   // template
   if (configs.runtimeOnly) {
     // runtimeOnly
-
-    function toFunction (code) {
-      // console.log(code);
-      return transpile('function render () {' + code + '}')
-    }
-
     if (output.template) {
       templateContent = fis.compile.partial(output.template.content, file, {
         ext: output.template.lang || 'html',
         isHtmlLike: true
       });
 
-      var compiled = compiler.compile(templateContent);
       var renderFun, staticRenderFns;
-
-      if (compiled.errors.length) {
-        compiled.errors.forEach(function (err) {
-          console.error('\n' + chalk.red(err) + '\n')
-        });
-        throw new Error('Vue template compilation failed');
-      } else {
-        renderFun = toFunction(compiled.render);
-        staticRenderFns = '[' + compiled.staticRenderFns.map(toFunction).join(',') + ']';
+      var result = compileTemplate(templateContent);
+      if(result){
+        renderFun = result.render;
+        staticRenderFns = result.staticRenderFns;
       }
     } else {
       renderFun = 'function(){}';

--- a/lib/insert-css.js
+++ b/lib/insert-css.js
@@ -1,0 +1,14 @@
+var uglifyJS = require('uglify-js');
+
+function insertCSS(styleContent) {
+  var styleNode = document.createElement("style");
+  styleNode.setAttribute("type", "text/css");
+  if (styleNode.styleSheet) {
+    styleNode.styleSheet.cssText = styleContent;
+  } else {
+    styleNode.appendChild(document.createTextNode(styleContent));
+  }
+  document.getElementsByTagName("head")[0].appendChild(styleNode);
+};
+
+module.exports = uglifyJS.minify(insertCSS.toString(), {fromString: true}).code;

--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -1,0 +1,22 @@
+var chalk = require('chalk')
+var vueCompiler = require('vue-template-compiler')
+var transpile = require('vue-template-es2015-compiler')
+
+module.exports = function compileTemplate (template) {
+  var compiled = vueCompiler.compile(template)
+  if (compiled.errors.length) {
+    compiled.errors.forEach(function (msg) {
+      console.error('\n' + chalk.red(msg) + '\n')
+    })
+    throw new Error('Vue template compilation failed')
+  } else {
+    return {
+      render: toFunction(compiled.render),
+      staticRenderFns: '[' + compiled.staticRenderFns.map(toFunction).join(',') + ']'
+    }
+  }
+}
+
+function toFunction (code) {
+  return transpile('function render () {' + code + '}')
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "chalk": "^1.1.3",
     "hash-sum": "^1.0.2",
     "object-assign": "^4.1.0",
+    "uglify-js": "^2.8.14",
     "vue-template-compiler": "^2.1.6",
     "vue-template-es2015-compiler": "^1.4.0"
   },


### PR DESCRIPTION
添加原因, 我倾向于将css内联到js中进行加载, 做到css和模板js的强关联, 而且还能同时加载.

如果内容太多的话, 可以分每个commit进行review

- 将template-compiler放到单独文件里, 方便和 vueify 还有 vue-loader进行比照升级
- 将runtimeOnly和template进行判断的逻辑更改了一下, 先去判断有没有template, 有的话, 才会进一步判断runtimeOnly的执行. 所以最终的结果是, 如果没有写模板的话, 就不会生成 `module.exports.render = function(){} module.exports.staticRenderFns = []` 这样的语句
- 在选项中增加extractCSS 默认为 true, 和目前逻辑保持一致. 如果设置为false, 则会将CSS内联到js中, 通过一个简化版的 `insert-css` 将css字符串添加到 head 中.

在做这一块的内容时,  曾经想过把 `output['styles']` 的所有内容整合成一个文件, 或者一个css字符串, 但是试验后发现, 如果使用scss的话, 会在文件头部插入 `@charset "UTF-8"`, 而这个 `@rule` 要求在css文件的顶部, 否则就是不合法的. 所以最终没有把css进行合并.

后续计划: 将 `scoped CSS` 做成和 vueify 还有 vue-loader一样的效果, 不需要在模板中手动去写占位符就自动的生成 scopedId