### PR TITLE
支持 vueify 和 vue-loader 形式的自动 scopeId, 不需要占位符

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ fis.match('src/**.vue', {
       // styleNameJoin
       styleNameJoin: '',          // 样式文件命名连接符 `component-xx-a.css`
 
+      extractCSS: true,           // 是否将css生成新的文件, 如果为false, 则会内联到js中
+
       // css scoped
-      ccssScopedFlag: '__vuec__', // 组件scoped占位符
       cssScopedIdPrefix: '_v-',   // hash前缀：_v-23j232jj
       cssScopedHashType: 'sum',   // hash生成模式，num：使用`hash-sum`, md5: 使用`fis.util.md5`
       cssScopedHashLength: 8,     // hash 长度，cssScopedHashType为md5时有效
@@ -116,7 +117,7 @@ fis.match('src/(component/**.css)', {
 
 参考[vue-loader](https://github.com/vuejs/vue-loader)源码，结合fis3的编译特性而编写,下面是parser阶段的主要过程：
 
-1. 解析vue文件，找到其中的`style`,'template','script'标签。
+1. 解析vue文件，找到其中的`style`,`template`,`script`标签。
 
 2. 每一个`style`标签创建一个对应的虚拟文件，后缀为`lang`属性指定，默认`css`，你可以指定`less`或其它的后缀。对创建虚拟文件，一样会进行fis3的编译流程（属性`lang`的值决定该文件怎么编译），并加入当前文件的依赖。
 
@@ -132,36 +133,14 @@ fis.match('src/(component/**.css)', {
 
 > 为了保证每一个组件样式的独立性，是当前组件定义的样式只在当前的组件内生效，引入css scoped机制。
 
-- 在模板的元素上（一般是根节点）加上scoped标志(class,attr,id)，默认为`__vuec__`， 你可以通过`cssScopedFlag`自定义。可以加在class，或者属性，或者id。
+- 在style标签中使用scoped标志。
 
-```html
-<template>
-  <div class="test" __vuec__></div>
-  <div class="test __vuec__"></div>
-</template>
-```
+    ```css
+    <style scoped></style>
+    <style lang="scss" scoped></style>
+    ```
 
-- 在样式中使用scoped标志。
-
-```css
-.test[__vuec__] {
-  //
-}
-// or
-.other.__vuec__ {
-
-}
-// or
-.__vuec__ {
-  .a {
-
-  }
-}
-```
-
-- scoped标志会根据文件路径生成唯一的hash字符串（如：`_v-23j232jj` ）;
-
-- 配置：scoped标志默认为`__vuec__`，你可以自定义。
+- scoped标志会根据文件路径生成唯一的hash字符串（如：`_v-23j232jj` ）
 
 ## 测试demo
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ fis.match('src/(component/**.css)', {
 
 ## 组件编写规范
 
-`style`标签可以有多个，`template`和`script`标签只能有一个，具体请参考[vue 单文件组件](http://vuejs.org.cn/guide/application.html)。
+`style`标签可以有多个，`template`和`script`标签只能有一个，具体请参考[vue 单文件组件](https://vuejs.org/v2/guide/single-file-components.html)。
 
 ## css scoped支持
 

--- a/index.js
+++ b/index.js
@@ -65,6 +65,13 @@ module.exports = function(content, file, conf) {
     isJsLike: true
   });
 
+  scriptStr += '\nvar __vue__options__;\n';
+  scriptStr += 'if(module.exports.__esModule && module.exports.default){\n';
+  scriptStr += '  __vue__options__ = module.exports.default;\n';
+  scriptStr += '}else{\n';
+  scriptStr += '  __vue__options__ = module.exports;\n';
+  scriptStr += '}\n';
+
   if(output.template){
     var templateContent = fis.compile.partial(output.template.content, file, {
       ext: output.template.lang || 'html',
@@ -74,17 +81,12 @@ module.exports = function(content, file, conf) {
     if(configs.runtimeOnly){
       var result = compileTemplate(templateContent);
       if(result){
-        scriptStr += '\n;\n(function(renderFun, staticRenderFns){\n'
-        scriptStr += '\nif(module && module.exports){ module.exports.render=renderFun; module.exports.staticRenderFns=staticRenderFns;}\n';
-        scriptStr += '\nif(exports && exports.default){ exports.default.render=renderFun; exports.default.staticRenderFns=staticRenderFns;}\n';
-        scriptStr += '\n})(' + result.render + ',' + result.staticRenderFns + ');\n';
+        scriptStr += '__vue__options__.render =' + result.render + '\n';
+        scriptStr += '__vue__options__.staticRenderFns =' + result.staticRenderFns + '\n';
       }
     }else{
       // template
-      scriptStr += '\n;\n(function(template){\n'
-      scriptStr += '\nmodule && module.exports && (module.exports.template = template);\n';
-      scriptStr += '\nexports && exports.default && (exports.default.template = template);\n';
-      scriptStr += '\n})(' + JSON.stringify(templateContent) + ');\n';
+      scriptStr += '__vue__options__.template = ' + JSON.stringify(templateContent) + '\n';
     }
   }
 

--- a/lib/gen-id.js
+++ b/lib/gen-id.js
@@ -1,0 +1,25 @@
+// utility for generating a uid for each component file
+// used in scoped CSS rewriting
+var hash = require('hash-sum')
+var cache = Object.create(null)
+
+// module.exports = function genId (file) {
+//   return cache[file] || (cache[file] = hash(file))
+// }
+
+module.exports = function genId(file, configs){
+  if(cache[file]){
+    return cache[file];
+  }
+
+  var scopeId;
+
+  // scope replace
+  if (configs.cssScopedType == 'sum') {
+    scopeId = hash(file.subpath);
+  } else {
+    scopeId = fis.util.md5(file.subpath, configs.cssScopedHashLength);
+  }
+
+  return cache[file] = scopeId;
+};

--- a/lib/gen-id.js
+++ b/lib/gen-id.js
@@ -8,8 +8,8 @@ var cache = Object.create(null)
 // }
 
 module.exports = function genId(file, configs){
-  if(cache[file]){
-    return cache[file];
+  if(cache[file.subpath]){
+    return cache[file.subpath];
   }
 
   var scopeId;
@@ -21,5 +21,5 @@ module.exports = function genId(file, configs){
     scopeId = fis.util.md5(file.subpath, configs.cssScopedHashLength);
   }
 
-  return cache[file] = scopeId;
+  return cache[file.subpath] = scopeId;
 };

--- a/lib/style-rewriter.js
+++ b/lib/style-rewriter.js
@@ -1,0 +1,89 @@
+var postcss = require('postcss')
+var selectorParser = require('postcss-selector-parser')
+var cache = require('lru-cache')(100)
+var assign = require('object-assign')
+
+var deasync = require('deasync')
+
+var currentId
+var addId = postcss.plugin('add-id', function () {
+  return function (root) {
+    root.each(function rewriteSelector (node) {
+      if (!node.selector) {
+        // handle media queries
+        if (node.type === 'atrule' && node.name === 'media') {
+          node.each(rewriteSelector)
+        }
+        return
+      }
+      node.selector = selectorParser(function (selectors) {
+        selectors.each(function (selector) {
+          var node = null
+          selector.each(function (n) {
+            if (n.type !== 'pseudo') node = n
+          })
+          selector.insertAfter(node, selectorParser.attribute({
+            attribute: currentId
+          }))
+        })
+      }).process(node.selector).result
+    })
+  }
+})
+
+/**
+ * Add attribute selector to css
+ *
+ * @param {String} id
+ * @param {String} css
+ * @param {Boolean} scoped
+ * @param {Object} options
+ * @return {Promise}
+ */
+
+module.exports = deasync(function (id, css, scoped, options, cbk) {
+  var key = id + '!!' + scoped + '!!' + css
+  var val = cache.get(key)
+  if (val) {
+    cbk(null, val)
+  } else {
+    var plugins = []
+    var opts = {}
+
+    // // do not support post plugins here, use fis3 style plugins
+    // if (options.postcss instanceof Array) {
+    //   plugins = options.postcss.slice()
+    // } else if (options.postcss instanceof Object) {
+    //   plugins = options.postcss.plugins || []
+    //   opts = options.postcss.options
+    // }
+
+    // scoped css rewrite
+    // make sure the addId plugin is only pushed once
+    if (scoped && plugins.indexOf(addId) === -1) {
+      plugins.push(addId)
+    }
+
+    // remove the addId plugin if the style block is not scoped
+    if (!scoped && plugins.indexOf(addId) !== -1) {
+      plugins.splice(plugins.indexOf(addId), 1)
+    }
+
+    // // do not support cssnano minification here, use fis3 style plugins
+    // // minification
+    // if (process.env.NODE_ENV === 'production') {
+    //   plugins.push(require('cssnano')(assign({
+    //     safe: true
+    //   }, options.cssnano)))
+    // }
+    currentId = id
+
+    postcss(plugins)
+      .process(css, opts)
+      .then(function (res) {
+        cache.set(key, res.css)
+        cbk(null, res.css)
+      })
+  }
+})
+

--- a/package.json
+++ b/package.json
@@ -12,8 +12,12 @@
   "main": "index.js",
   "dependencies": {
     "chalk": "^1.1.3",
+    "deasync": "^0.1.9",
     "hash-sum": "^1.0.2",
+    "lru-cache": "^4.0.2",
     "object-assign": "^4.1.0",
+    "postcss": "^5.2.16",
+    "postcss-selector-parser": "^2.2.3",
     "uglify-js": "^2.8.14",
     "vue-template-compiler": "^2.1.6",
     "vue-template-es2015-compiler": "^1.4.0"

--- a/test/src/component/a.vue
+++ b/test/src/component/a.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="component-a" __vuec__>
+  <div class="component-a">
     Component A
   </div>
 </template>
@@ -15,13 +15,13 @@
   }
 </script>
 
-<style lang="less">
+<style lang="less" scoped>
 body {
   a {
     color: inherit;
   }
 }
-.component-a[__vuec__] {
+.component-a {
   line-height: 50px;
   text-align: center;
   color: #fff;

--- a/test/src/component/index.vue
+++ b/test/src/component/index.vue
@@ -1,7 +1,7 @@
 
-<style lang="less">
+<style lang="less" scoped>
 @import "../less/other.less";
-.index.__vuec__ {
+.index {
   > p {
     line-height: 50px;
     text-align: center;
@@ -23,7 +23,7 @@ $blue : #1875e7;　
 </style>
 
 <template>
-  <div class="index __vuec__" >
+  <div class="index" >
     <p>fis3-parser-vue-component demo runing ~</p>
     <component-a></component-a>
     <component-b></component-b>

--- a/test2/src/component/a.vue
+++ b/test2/src/component/a.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <div class="component-a" __vuec__>
+  <div class="component-a">
     Component A
   </div>
 </template>
@@ -15,13 +15,13 @@
   }
 </script>
 
-<style lang="less">
+<style lang="less" scoped>
 body {
   a {
     color: inherit;
   }
 }
-.component-a[__vuec__] {
+.component-a {
   line-height: 50px;
   text-align: center;
   color: #fff;

--- a/test2/src/component/index.vue
+++ b/test2/src/component/index.vue
@@ -1,7 +1,7 @@
 
-<style lang="less">
+<style lang="less" scoped>
 @import "../less/other.less";
-.index.__vuec__ {
+.index {
   > p {
     line-height: 50px;
     text-align: center;
@@ -23,7 +23,7 @@ $blue : #1875e7;　
 </style>
 
 <template>
-  <div class="index __vuec__" >
+  <div class="index" >
     <p>fis3-parser-vue-component demo runing ~</p>
     <component-a></component-a>
     <component-b></component-b>


### PR DESCRIPTION
此修改涉及到 **break change**, 删除了一个选项`cssScopedFlag`, 会导致目前依赖此特性的代码出问题

- 类似 vueify vue-loader, 添加 `__vue_options__`, 避免每次都需要去判断当前是 exports.defaut 还是 module.exports.
判断的标准是, module.exports.__esModule 和 module.exports.default存在, 则使用
exports.default, 否则使用 module.exports
- 将scopeId生成逻辑像vueify vue-loader一样, 放入 gen-id.js 中, 但是对
   vueify的逻辑做了修改, 仍然支持 `cssScopedIdPrefix`, `cssScopedHashType`,
   `cssScopedHashLength` 等选项
- 复用 vueify vue-loader 中的 style-rewriter.js, 通过deasync 模块, 将异
   步逻辑转变成同步, 同时不block线程, 方便配置fis3的同步逻辑
- 在css片断编译后, 执行 rewriteStyle, 添加scopeId
- 删除原来的 `replaceScopedFlag` 方法
- 删除已经用不到的选项 `cssScopedFlag` 和变量 `vuecId`
- README文件更新

    - 修复 vue 单文件组件链接 
    - 删除`cssScopedFlag`
    - 更新`scoped`使用示例
    - 在test{,2}中删除`__vuec__`占位符, 使用scoped flag